### PR TITLE
Added db as required on all collection-document hooks

### DIFF
--- a/packages/core/src/services/collection-documents/delete-multiple.ts
+++ b/packages/core/src/services/collection-documents/delete-multiple.ts
@@ -79,6 +79,7 @@ const deleteMultiple = async (
 			collectionInstance: collectionInstance,
 		},
 		{
+			db: serviceConfig.db,
 			meta: {
 				collectionKey: data.collectionKey,
 				userId: data.userId,
@@ -119,6 +120,7 @@ const deleteMultiple = async (
 			collectionInstance: collectionInstance,
 		},
 		{
+			db: serviceConfig.db,
 			meta: {
 				collectionKey: data.collectionKey,
 				userId: data.userId,

--- a/packages/core/src/services/collection-documents/delete-single.ts
+++ b/packages/core/src/services/collection-documents/delete-single.ts
@@ -67,6 +67,7 @@ const deleteSingle = async (
 			collectionInstance: collectionInstance,
 		},
 		{
+			db: serviceConfig.db,
 			meta: {
 				collectionKey: data.collectionKey,
 				userId: data.userId,
@@ -107,6 +108,7 @@ const deleteSingle = async (
 			collectionInstance: collectionInstance,
 		},
 		{
+			db: serviceConfig.db,
 			meta: {
 				collectionKey: data.collectionKey,
 				userId: data.userId,

--- a/packages/core/src/services/collection-documents/upsert-single.ts
+++ b/packages/core/src/services/collection-documents/upsert-single.ts
@@ -84,6 +84,7 @@ const upsertSingle = async (
 			collectionInstance: collectionInstance,
 		},
 		{
+			db: serviceConfig.db,
 			meta: {
 				collectionKey: data.collectionKey,
 				userId: data.userId,
@@ -127,6 +128,7 @@ const upsertSingle = async (
 			collectionInstance: collectionInstance,
 		},
 		{
+			db: serviceConfig.db,
 			meta: {
 				collectionKey: data.collectionKey,
 				userId: data.userId,

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,5 +1,6 @@
 import type { BrickSchema } from "../schemas/collection-bricks.js";
 import type { FieldCollectionSchema } from "../schemas/collection-fields.js";
+import type { KyselyDB } from "../libs/db/types.js";
 
 // --------------------------------------------------
 // types
@@ -30,6 +31,7 @@ export type ArgumentsType<T> = T extends (...args: infer U) => unknown
 export type HookServiceHandlers = {
 	"collection-documents": {
 		beforeUpsert: (props: {
+			db: KyselyDB;
 			meta: {
 				collectionKey: string;
 				userId: number;
@@ -47,6 +49,7 @@ export type HookServiceHandlers = {
 			  }>
 			| Promise<void>;
 		afterUpsert: (props: {
+			db: KyselyDB;
 			meta: {
 				collectionKey: string;
 				userId: number;
@@ -58,6 +61,7 @@ export type HookServiceHandlers = {
 			};
 		}) => Promise<void>;
 		beforeDelete: (props: {
+			db: KyselyDB;
 			meta: {
 				collectionKey: string;
 				userId: number;
@@ -67,6 +71,7 @@ export type HookServiceHandlers = {
 			};
 		}) => Promise<void>;
 		afterDelete: (props: {
+			db: KyselyDB;
 			meta: {
 				collectionKey: string;
 				userId: number;


### PR DESCRIPTION
In preparation for the nested document plugin hooks now require a db instnace to be passed down. 

This is passed down instead of imported from the core package so that its a Kysely Transaction instance if the service that calls the hook is within a transaction.